### PR TITLE
Update Stopwatch.cpp

### DIFF
--- a/Sgl/Tools/Time/Stopwatch.cpp
+++ b/Sgl/Tools/Time/Stopwatch.cpp
@@ -1,46 +1,85 @@
-#include "Stopwatch.h"
+#include "Stopwatch.h" // Assuming the declaration is in Stopwatch.h
 
 namespace Sgl
 {
-	void Stopwatch::Start()
-	{
-		if(!_running)
-		{
-			_start = std::chrono::high_resolution_clock::now();
-			_running = true;
-		}
-	}
+    // Constructor
+    Stopwatch::Stopwatch() noexcept
+        : _currentIntervalStartTime(Clock::now()), // Initialize, though Start() will overwrite
+          _accumulatedDuration(Duration::zero()),
+          _isRunning(false)
+    {
+    }
 
-	void Stopwatch::Restart()
-	{
-		_running = false;
-		Reset();
-		Start();
-	}
+    void Stopwatch::Start()
+    {
+        if (!_isRunning)
+        {
+            _currentIntervalStartTime = Clock::now();
+            _isRunning = true;
+        }
+        // If already running, it continues from the existing _currentIntervalStartTime.
+        // Some implementations might choose to throw an error or restart the interval.
+        // This version mirrors the original's behavior of doing nothing if already running.
+    }
 
-	void Stopwatch::Reset()
-	{
-		_start = std::chrono::high_resolution_clock::now();
-		_elapsed = TimeSpan::Zero();
-	}
+    void Stopwatch::Stop() // This was effectively the original Pause()
+    {
+        if (_isRunning)
+        {
+            const auto now = Clock::now();
+            _accumulatedDuration += (now - _currentIntervalStartTime);
+            _isRunning = false;
+            // _currentIntervalStartTime now holds the start of the just-stopped interval.
+            // If Start() is called again, it will be updated.
+        }
+        // If not running, do nothing.
+    }
 
-	void Stopwatch::Pause()
-	{
-		if(_running)
-		{
-			_elapsed += GetEplapsedTime();
-			_running = false;
-		}
-	}
+    void Stopwatch::Reset() noexcept
+    {
+        _accumulatedDuration = Duration::zero();
+        _currentIntervalStartTime = Clock::now(); // Reset start point for a potential next Start()
+        _isRunning = false;
+    }
 
-	TimeSpan Stopwatch::Elapsed()
-	{
-		if(_running)
-		{
-			_elapsed += GetEplapsedTime();
-			_start = std::chrono::high_resolution_clock::now();
-		}
+    void Stopwatch::Restart()
+    {
+        // The original Restart did `_running = false; Reset(); Start();`
+        // Since our Reset() now sets _isRunning = false, this is simpler.
+        Reset();
+        Start();
+    }
 
-		return _elapsed;
-	}
-}
+    [[nodiscard]] Stopwatch::Duration Stopwatch::GetTotalElapsed() const
+    {
+        if (_isRunning)
+        {
+            const auto now = Clock::now();
+            return _accumulatedDuration + (now - _currentIntervalStartTime);
+        }
+        else
+        {
+            return _accumulatedDuration;
+        }
+    }
+
+    Stopwatch::Duration Stopwatch::RecordLapAndGetTotalElapsed() // This was the original Elapsed()
+    {
+        if (_isRunning)
+        {
+            const auto now = Clock::now();
+            _accumulatedDuration += (now - _currentIntervalStartTime);
+            _currentIntervalStartTime = now; // Reset for the next "lap" or segment
+        }
+        // If not running, it simply returns the currently accumulated duration
+        // without changing any state, consistent with original behavior where
+        // the update part was conditional on _running.
+        return _accumulatedDuration;
+    }
+
+    [[nodiscard]] bool Stopwatch::IsRunning() const noexcept
+    {
+        return _isRunning;
+    }
+
+} // namespace Sgl

--- a/Sgl/Tools/Time/Stopwatch.h
+++ b/Sgl/Tools/Time/Stopwatch.h
@@ -1,27 +1,66 @@
-#pragma once
+#pragma once // Modern include guard
 
-#include "TimeSpan.h"
-#include <chrono>
+#include <chrono> // Required for std::chrono types and functions
 
 namespace Sgl
 {
-	class Stopwatch
-	{
-	private:
-		bool _running = false;
-		TimeSpan _elapsed = TimeSpan::Zero();
-		std::chrono::steady_clock::time_point _start;
-	public:
-		void Start();
-		void Restart();
-		void Reset();
-		void Pause();
-		bool IsRunning() const { return _running; }
-		TimeSpan Elapsed();
-	private:
-		TimeSpan GetEplapsedTime()
-		{
-			return TimeSpan((std::chrono::high_resolution_clock::now() - _start).count());
-		}
-	};
-}
+    class Stopwatch
+    {
+    public:
+        // Type aliases for clarity and potentially easier changes later
+        using Clock = std::chrono::steady_clock; // Use steady_clock for monotonic timing
+        using TimePoint = Clock::time_point;
+        using Duration = Clock::duration;      // Represents the native duration of the clock
+
+        // Constructor
+        Stopwatch() noexcept;
+
+        // Core stopwatch controls
+        void Start();                          // Starts or resumes timing.
+        void Stop();                           // Stops timing and accumulates the current interval.
+        void Reset() noexcept;                 // Resets accumulated time and stops the timer.
+        void Restart();                        // Convenience: Resets, then starts the timer.
+
+        // Get elapsed time
+        // Returns the total accumulated duration, including the current running interval (if any).
+        // This method is const and does not alter the stopwatch's state.
+        [[nodiscard]] Duration GetTotalElapsed() const;
+
+        // Mimics the original Elapsed() behavior:
+        // If running, adds the current interval to the accumulated total,
+        // then resets the start of the current interval (like a lap timer).
+        // Returns the total accumulated duration after this operation.
+        Duration RecordLapAndGetTotalElapsed();
+
+        // Status
+        [[nodiscard]] bool IsRunning() const noexcept;
+
+        // Convenience template functions to get elapsed time in specific units
+        template<typename T_Duration = std::chrono::milliseconds>
+        [[nodiscard]] typename T_Duration::rep GetTotalElapsedCount() const {
+            return std::chrono::duration_cast<T_Duration>(GetTotalElapsed()).count();
+        }
+
+        template<typename Rep = double, typename Period = std::ratio> // e.g., Period = std::milli for ms
+        [[nodiscard]] Rep GetTotalElapsedAs() const {
+            return std::chrono::duration<Rep, Period>(GetTotalElapsed()).count();
+        }
+        
+        template<typename T_Duration = std::chrono::milliseconds>
+        typename T_Duration::rep RecordLapAndGetTotalElapsedCount() {
+            return std::chrono::duration_cast<T_Duration>(RecordLapAndGetTotalElapsed()).count();
+        }
+
+        template<typename Rep = double, typename Period = std::ratio>
+        Rep RecordLapAndGetTotalElapsedAs() {
+             return std::chrono::duration<Rep, Period>(RecordLapAndGetTotalElapsed()).count();
+        }
+
+
+    private:
+        TimePoint _currentIntervalStartTime; // Start time of the current (or most recent) timing interval
+        Duration _accumulatedDuration;       // Sum of durations of all completed intervals
+        bool _isRunning;                     // True if the stopwatch is currently timing
+    };
+
+} // namespace Sgl


### PR DESCRIPTION
Clarity and Predictability: The roles of Stop(), GetTotalElapsed(), and RecordLapAndGetTotalElapsed() are now more distinct and align better with common expectations for stopwatch functionality.
Robustness: Using std::chrono::steady_clock ensures reliable time measurement, unaffected by system time changes.
Modern C++ Practices: Incorporates const, noexcept, [[nodiscard]], and direct use of standard library features (std::chrono).
Elimination of Custom TimeSpan: By using std::chrono::duration directly, the code becomes more standard and avoids the need for a custom TimeSpan class (unless that class had other specific functionalities not shown).
Reset() Behavior: Reset() now consistently puts the stopwatch into a stopped state with zero accumulated time, ready for a fresh start.
Restart() Simplicity: Restart() is now a cleaner composition of Reset() and Start().
Informative Naming: _currentIntervalStartTime and _accumulatedDuration better describe the purpose of the internal state variables.
Convenience Getters: The templated GetTotalElapsedCount() and GetTotalElapsedAs() (and their "RecordLap" counterparts) make it easy to retrieve the duration in various units (e.g., milliseconds, seconds as double, etc.) without manual casting by the user.